### PR TITLE
Serve assets via CloudFront; drop Babel for SWC

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-    "presets": ["next/babel"],
-    "plugins": [["styled-components", { "ssr": true }]]
-}

--- a/AssetConfig.ts
+++ b/AssetConfig.ts
@@ -1,0 +1,10 @@
+// Photo assets are served through CloudFront (distribution E2AKQTW7LH879C), which fronts
+// the yearbook-assets S3 bucket. The distribution also attaches a long-lived Cache-Control
+// via a response headers policy -- the S3 objects themselves carry no cache headers at all.
+//
+// Set NEXT_PUBLIC_ASSET_HOST to override, e.g. to fall back to the bucket directly
+// ('yearbook-assets.s3.amazonaws.com') without a code change.
+export const ASSET_HOST =
+  process.env.NEXT_PUBLIC_ASSET_HOST || 'd2nk87d9flz1jw.cloudfront.net';
+
+export const assetUrl = (key: string) => `https://${ASSET_HOST}/${key}`;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,10 +94,14 @@ Images are **read** through CloudFront, not directly from S3. The bucket remains
 The S3 objects carry **no** `Cache-Control` of their own. CloudFront attaches one at the edge via response headers policy `05df1ff4-a688-4ef8-b6bc-88d7583ad677` (`yearbook-assets-long-cache`), which sets:
 
 ```
-Cache-Control: public, max-age=31536000, immutable
+Cache-Control: public, max-age=86400, stale-while-revalidate=604800
 ```
 
-**This means overwriting an existing key is effectively permanent for anyone who already loaded it.** Keys are timestamp-based so this rarely comes up, but if you do replace a photo in place, prefer uploading under a new filename. A CloudFront invalidation clears the edge cache but cannot clear browsers that already cached the old bytes:
+Deliberately **not** `immutable`, and deliberately a day rather than a year: old shots get re-edited and re-uploaded in place, especially around December/January, so updates have to be able to propagate. A viewer sees a re-edited photo within a day on their own, and `stale-while-revalidate` means they get the cached copy instantly while the new one fetches in the background.
+
+This lines up with the edge, which also holds one day -- because S3 sends no `Cache-Control`, CloudFront falls back to the `CachingOptimized` cache policy's 86400s `DefaultTTL`.
+
+To push an update out immediately rather than waiting a day, invalidate the edge:
 
 ```bash
 aws cloudfront create-invalidation --distribution-id E2AKQTW7LH879C --paths "/2025/2000px/*"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,11 +76,34 @@ for i in *.MOV; do ffmpeg -ss 00:00:00.000 -i "$i" -pix_fmt rgb24 -r 12 -vf 'sca
 
 ### S3 Integration
 
-The app fetches image lists from S3 using AWS SDK in `getServerSideProps`:
+The app fetches image lists from S3 using AWS SDK v3 in `getServerSideProps`:
 - Requires environment variables: `AWS_S3_ACCESS_KEY`, `AWS_S3_SECRET`
 - Bucket: `yearbook-assets`
-- Image URLs follow pattern: `https://yearbook-assets.s3.amazonaws.com/{year}/{size}/{filename}`
 - Supported formats: jpg, gif, webp
+- Listing is paginated via `paginateListObjectsV2` -- a bare `ListObjectsV2` silently caps at 1000 keys, and the larger years are already past 700
+
+### Asset delivery (CloudFront)
+
+Images are **read** through CloudFront, not directly from S3. The bucket remains public, so direct S3 URLs still work as a fallback.
+
+- Distribution: `E2AKQTW7LH879C` -> `d2nk87d9flz1jw.cloudfront.net`
+- Origin: `yearbook-assets.s3.us-east-1.amazonaws.com`
+- Image URLs follow pattern: `https://d2nk87d9flz1jw.cloudfront.net/{year}/{size}/{filename}`
+- Built via `assetUrl()` in `AssetConfig.ts` -- the single place the host is defined. Override with `NEXT_PUBLIC_ASSET_HOST` (e.g. set it to `yearbook-assets.s3.amazonaws.com` to bypass the CDN without a code change).
+
+The S3 objects carry **no** `Cache-Control` of their own. CloudFront attaches one at the edge via response headers policy `05df1ff4-a688-4ef8-b6bc-88d7583ad677` (`yearbook-assets-long-cache`), which sets:
+
+```
+Cache-Control: public, max-age=31536000, immutable
+```
+
+**This means overwriting an existing key is effectively permanent for anyone who already loaded it.** Keys are timestamp-based so this rarely comes up, but if you do replace a photo in place, prefer uploading under a new filename. A CloudFront invalidation clears the edge cache but cannot clear browsers that already cached the old bytes:
+
+```bash
+aws cloudfront create-invalidation --distribution-id E2AKQTW7LH879C --paths "/2025/2000px/*"
+```
+
+Adding *new* files needs no invalidation -- they were never cached.
 
 ### Styling
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ This application displays the photos for my annual yearbook project.
 # Some vitals:
 - Built with [Next.js](https://nextjs.org/)
 - Media stored in S3 in multiple sizes -- allows the best size to be used depending on the case (e.g. 1000px for the main grid, 3000px for the lightbox)
+- Served through CloudFront (`d2nk87d9flz1jw.cloudfront.net`) so images are edge-cached rather than pulled from us-east-1 on every view
 - Images are loaded in batches as the user scrolls to keep initial load time fast.
 - Hosted on Vercel
 
@@ -15,6 +16,9 @@ This application displays the photos for my annual yearbook project.
 ## Sync assets to S3
 - `cd $LOCAL_PHOTO_DIRECTORY`
 - `aws s3 sync . s3://yearbook-assets/ --delete --acl public-read --profile default --exclude "*" --include "*.jpg" --include "*.webp" --include "*.gif" --size-only`
+
+New files need no CloudFront invalidation. If you *overwrite* an existing key, invalidate it -- and note that browsers which already cached it will keep the old copy for up to a year, so uploading under a new filename is safer:
+- `aws cloudfront create-invalidation --distribution-id E2AKQTW7LH879C --paths "/2025/2000px/*"`
 
 ## Converting jpgs --> webp
 `for f in *.jpg; do cwebp -q 85 -m 6 -af "$f" -o "${f%.jpg}.webp"; done`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This application displays the photos for my annual yearbook project.
 - `cd $LOCAL_PHOTO_DIRECTORY`
 - `aws s3 sync . s3://yearbook-assets/ --delete --acl public-read --profile default --exclude "*" --include "*.jpg" --include "*.webp" --include "*.gif" --size-only`
 
-New files need no CloudFront invalidation. If you *overwrite* an existing key, invalidate it -- and note that browsers which already cached it will keep the old copy for up to a year, so uploading under a new filename is safer:
+New files need no CloudFront invalidation. If you *overwrite* an existing shot, it propagates on its own within a day (assets are cached for 24h, not permanently). To push it out immediately:
 - `aws cloudfront create-invalidation --distribution-id E2AKQTW7LH879C --paths "/2025/2000px/*"`
 
 ## Converting jpgs --> webp

--- a/components/AlbumContent.tsx
+++ b/components/AlbumContent.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 
 import styled from 'styled-components';
+import { assetUrl } from '../AssetConfig';
 // import LazyImage from './LazyImage';
 
 type TParams =  { id: string };
@@ -64,12 +65,12 @@ export default class AlbumContent extends Component<IOwnProps, IOwnState> {
   getImageUrlBySize(path: string, size: string) {
     // Experimenting with future full video support
     // if (size === '3000px' && path.indexOf('.gif') > 0) {
-    //   return `https://yearbook-assets.s3.amazonaws.com/${path.replace('.gif', '.mov')}`;
+    //   return assetUrl(path.replace('.gif', '.mov'));
     // } else {
-    //   return `https://yearbook-assets.s3.amazonaws.com/${path.replace('200px', size)}`;
+    //   return assetUrl(path.replace('200px', size));
     // }
 
-    return `https://yearbook-assets.s3.amazonaws.com/${path.replace(IMAGE_SIZES.SMALL, size)}`;
+    return assetUrl(path.replace(IMAGE_SIZES.SMALL, size));
   }
 
   isBottom(el: HTMLElement) {

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,11 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  compiler: {
+    // Replaces the babel-plugin-styled-components config that used to live in .babelrc.
+    // Keeping it here lets Next use SWC/Turbopack instead of falling back to Babel.
+    styledComponents: true,
+  },
   images: {
     remotePatterns: [
       {

--- a/next.config.js
+++ b/next.config.js
@@ -10,6 +10,13 @@ module.exports = {
     remotePatterns: [
       {
         protocol: 'https',
+        hostname: 'd2nk87d9flz1jw.cloudfront.net',
+        port: '',
+        pathname: '/**',
+      },
+      // Kept so NEXT_PUBLIC_ASSET_HOST can fall back to the bucket without a code change.
+      {
+        protocol: 'https',
         hostname: 'yearbook-assets.s3.amazonaws.com',
         port: '',
         pathname: '/**',

--- a/pages/album/[aid].tsx
+++ b/pages/album/[aid].tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 
 import { ThemeProvider } from "styled-components";
 import { lightTheme, darkTheme, GlobalStyles, THEMES } from '../../ThemeConfig';
+import { assetUrl } from '../../AssetConfig';
 import Link from 'next/link';
 import { TopBar, MainContentWrapper, MainContent, Header, LightSwitch } from '../../components/SharedComponents';
 import Lightbox from "yet-another-react-lightbox";
@@ -122,7 +123,7 @@ const Album = (data: any) => {
             close={() => setLightboxOpen(false)}
             index={lightboxIndex}
             slides={images.map((path: string) => ({
-              src: `https://yearbook-assets.s3.amazonaws.com/${path.replace('200px', '3000px')}`
+              src: assetUrl(path.replace('200px', '3000px'))
             }))}
           />
         </MainContent>


### PR DESCRIPTION
Two follow-ups from the deferred list in #16. Three commits, independently reviewable.

## 1. Drop `.babelrc` for the SWC styled-components transform

Next 16 defaults to Turbopack, but a custom Babel config forces it back onto Babel for every compile — Next has warned about this on every build since the 16 upgrade. Moving the transform to `compiler.styledComponents` in `next.config.js` lets SWC handle it.

**Production compile: ~1180ms → ~500ms.**

Verified styled-components rules still apply (`object-fit`, `flex-wrap`, `display: flex`), class names still generate, no hydration warnings.

> Noted while testing, **not** changed here: there's no `pages/_document.tsx` wiring up `ServerStyleSheet`, so styled-components CSS has never been server-rendered — the SSR HTML contains zero style rules and everything is injected after hydration. I confirmed this is identical before and after the Babel change, so it's pre-existing, but it's a real first-paint cost worth a separate look.

## 2. Serve photo assets through CloudFront

Images were pulled straight from `yearbook-assets` in us-east-1 on every view, with no edge caching. While setting this up I found that **none of the 17,377 objects (23.7 GB) carry a `Cache-Control` header at all**, so browsers were revalidating constantly.

- Distribution `E2AKQTW7LH879C` → `d2nk87d9flz1jw.cloudfront.net`, origin `yearbook-assets.s3.us-east-1.amazonaws.com`
- **Bucket stays public**, so existing direct S3 URLs keep working and fallback is safe
- A response headers policy attaches `Cache-Control: public, max-age=86400, stale-while-revalidate=604800` at the edge — this avoids rewriting all 17k objects to add the header at the origin
- The host was hardcoded in two places; both now route through `assetUrl()` in `AssetConfig.ts`, overridable via `NEXT_PUBLIC_ASSET_HOST` to bypass the CDN without a code change
- `PriceClass_100` (NA + Europe), HTTP/2 + HTTP/3, compression on

**Measured:** warm CloudFront ~0.23s vs ~0.37–0.53s direct from S3. That gap widens the further a viewer is from us-east-1. CloudFront's perpetual free tier (1 TB/month egress) should cover this comfortably, and CloudFront egress is marginally cheaper per GB than S3's.

### On cache lifetime

Deliberately **not** `immutable`, and a day rather than a year. Old shots get re-edited and re-uploaded in place — especially around December/January — so updates have to be able to propagate. A viewer picks up a re-edited photo within a day on their own, and `stale-while-revalidate` keeps it feeling instant by serving the cached copy while the new one fetches behind it.

This also matches what the edge actually does: since S3 sends no `Cache-Control`, CloudFront falls back to the `CachingOptimized` policy's 86400s `DefaultTTL`. To push an update out immediately, invalidate — the command is in both `README.md` and `CLAUDE.md`. New files never need invalidation.

## Verification

| Check | Result |
|---|---|
| All grid + lightbox URLs via CDN | yes — **0** direct-S3 requests |
| `Cache-Control` injected at edge | `public, max-age=86400, stale-while-revalidate=604800` (S3 sends none) |
| Edge caching | Miss → Hit → Hit confirmed |
| jpg / webp / gif | all 200 with correct content-type |
| 3000px lightbox path | 200 via CDN, opens correctly |
| Images loaded / failed | 15 / **0** |
| styled-components after Babel removal | rules apply, no hydration warnings |
| `tsc --noEmit` / `npm run build` | clean |

## Still open from the original list

`srcset`/`sizes` remains the biggest single win — one 2000px grid image is ~530KB vs 56KB at 200px, and mobile currently downloads the full 2000px file. The caching strategy for `getServerSideProps` (SSR `s-maxage` vs ISR) is also still undecided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
