### PR TITLE
Album explorer: timeline rail, photo permalinks, and year previews

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "yearbook-dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000,
+      "autoPort": true
+    },
+    {
+      "name": "yearbook-demo",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "NEXT_DIST_DIR=.next-demo npx next start"],
+      "port": 3100,
+      "autoPort": true
+    }
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 
 # next.js
 /.next/
+# Alternate build dir for a second concurrent `next dev`/`next start` -- see NEXT_DIST_DIR
+# in next.config.js.
+/.next-*/
 /out/
 
 # production

--- a/ThemeConfig.ts
+++ b/ThemeConfig.ts
@@ -1,24 +1,32 @@
 import { createGlobalStyle} from 'styled-components'
 
-interface ThemeType {
+export interface ThemeType {
   name: string,
   body: string,
   text: string,
   icon: string,
+  // Used by the timeline rail: `accent` marks the month you are currently scrolled
+  // through, `railBackground` is the translucent plate the rail floats on.
+  accent: string,
+  railBackground: string,
 }
 
-export const lightTheme = {
+export const lightTheme: ThemeType = {
   name: 'light',
   body: '#e6e6e6',
   text: '#1b1b1b',
   icon: '☀️',
+  accent: '#3f06dd',
+  railBackground: 'rgba(230, 230, 230, 0.82)',
 }
 
-export const darkTheme = {
+export const darkTheme: ThemeType = {
   name: 'dark',
   body: '#1b1b1b',
   text: '#e6e6e6',
   icon: '🌗',
+  accent: '#8a6bff',
+  railBackground: 'rgba(27, 27, 27, 0.82)',
 }
 
 export const GlobalStyles = createGlobalStyle<{theme: ThemeType}>`

--- a/components/AlbumContent.tsx
+++ b/components/AlbumContent.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { assetUrl } from '../AssetConfig';
 // import LazyImage from './LazyImage';
 
-type TParams =  { id: string };
 const BATCH_SIZE = 15;
 
 const IMAGE_SIZES = {
@@ -14,14 +13,20 @@ const IMAGE_SIZES = {
   LARGE: '3000px',
 }
 
+// Every rendered tile carries its absolute index in the album so the timeline rail can
+// scroll to one and so we can work out which photo is currently under the header.
+export const PHOTO_INDEX_ATTR = 'data-photo-index';
+export const photoDomId = (index: number) => `photo-${index}`;
+
 interface IOwnProps {
   items: string[],
   year: string,
   onImageClick: (index: number) => void,
+  onVisibleIndexChange?: (index: number) => void,
 }
 
 interface IOwnState {
-  items: any,
+  items: string[],
   imageSizeMed: string,
   imageSizeLarge: string,
   renderItems: string[],
@@ -30,7 +35,10 @@ interface IOwnState {
 }
 
 export default class AlbumContent extends Component<IOwnProps, IOwnState> {
-  constructor (props: any) {
+  private visibleIndex = -1;
+  private scanQueued = false;
+
+  constructor (props: IOwnProps) {
     super(props);
     const { year, items } = props;
     // Seed the first batch here rather than in componentDidMount so it is present in the
@@ -47,14 +55,19 @@ export default class AlbumContent extends Component<IOwnProps, IOwnState> {
   }
 
   componentDidMount() {
-    document.addEventListener('scroll', this.trackScrolling);
+    document.addEventListener('scroll', this.onScroll, { passive: true });
 
     const intervalId = setInterval(this.trackScrolling, 500);
     this.setState({ intervalId: intervalId });
+
+    // Highlight the month you land on, before any scrolling happens.
+    this.scanVisible();
   }
 
   componentWillUnmount() {
     const { intervalId } = this.state;
+
+    document.removeEventListener('scroll', this.onScroll);
 
     // Use intervalId from the state to clear the interval
     if (intervalId) {
@@ -77,30 +90,68 @@ export default class AlbumContent extends Component<IOwnProps, IOwnState> {
     // 1000px from the bottom
     return el.getBoundingClientRect().bottom <= window.innerHeight + 1500;
   }
-    
+
+  // Renders every batch up to and including `index`, then runs `done` once those tiles are
+  // actually in the DOM. The timeline rail uses this to reach a month far down the album
+  // that lazy loading hasn't gotten to yet.
+  revealThrough = (index: number, done?: () => void) => {
+    const { items, offset } = this.state;
+
+    if (index < offset) {
+      done?.();
+      return;
+    }
+
+    // Round up to a whole batch past the target so the jump lands mid-run rather than
+    // right at the loading edge.
+    const newOffset = Math.min(items.length, (Math.floor(index / BATCH_SIZE) + 2) * BATCH_SIZE);
+
+    this.setState({ renderItems: items.slice(0, newOffset), offset: newOffset }, done);
+  };
+
+  onScroll = () => {
+    this.trackScrolling();
+    this.scanVisible();
+  };
+
+  // Reports the topmost photo still on screen so the rail can highlight the month you are
+  // actually looking at. rAF-throttled because it touches layout for every rendered tile.
+  scanVisible = () => {
+    const { onVisibleIndexChange } = this.props;
+    if (!onVisibleIndexChange || this.scanQueued) return;
+
+    this.scanQueued = true;
+    window.requestAnimationFrame(() => {
+      this.scanQueued = false;
+
+      const tiles = document.querySelectorAll<HTMLElement>(`[${PHOTO_INDEX_ATTR}]`);
+      for (const tile of Array.from(tiles)) {
+        // First tile whose bottom edge is still below the top of the viewport.
+        if (tile.getBoundingClientRect().bottom > 80) {
+          const index = Number(tile.getAttribute(PHOTO_INDEX_ATTR));
+          if (!Number.isNaN(index) && index !== this.visibleIndex) {
+            this.visibleIndex = index;
+            onVisibleIndexChange(index);
+          }
+          return;
+        }
+      }
+    });
+  };
+
   trackScrolling = () => {
-    const { items, offset, renderItems } = this.state;
+    const { items, offset } = this.state;
 
     const wrappedElement = document.getElementById('page-main-grid');
     if (wrappedElement && this.isBottom(wrappedElement) && (items.length > offset)) {
-      console.log('header bottom reached');
-      // console.log("items", items)
-      // console.log("itemslength", items.length)
-      // console.log("renderItemsLength", renderItems.length)
-      // console.log("offset", offset)
-      // console.log("offset", offset)
-
       // Rudimentary lazy loading.
       const newOffset = offset + BATCH_SIZE;
-      const newRenderItems = items.slice(0, newOffset);
-      // console.log("newOffset", newOffset)
-      // console.log("newrenderItemsLength", renderItems.length)
+
       this.setState({
         items,
-        renderItems: newRenderItems,
+        renderItems: items.slice(0, newOffset),
         offset: newOffset,
       });
-      document.removeEventListener('scroll', this.trackScrolling);
     }
   };
 
@@ -109,7 +160,7 @@ export default class AlbumContent extends Component<IOwnProps, IOwnState> {
       const { onImageClick } = this.props;
       const imageList = imagePaths.map((p: string, index: number) => {
         return (
-          <ItemWrapper key={index}>
+          <ItemWrapper key={index} id={photoDomId(index)} {...{ [PHOTO_INDEX_ATTR]: index }}>
             <FlexImage
               src={this.getImageUrlBySize(p, imageSizeMed)}
               loading="lazy"
@@ -125,7 +176,7 @@ export default class AlbumContent extends Component<IOwnProps, IOwnState> {
 
   render() {
     const { renderItems } = this.state;
-    
+
     return (
       <GridWrapper>
         {this.childElements(renderItems)}
@@ -156,6 +207,14 @@ const ItemWrapper = styled.span`
   height: 50vh;
   flex-grow: 1;
   margin: 6px;
+  /* Offsets the jump target so a scrolled-to photo doesn't sit under the sticky header. */
+  scroll-margin-top: 80px;
+  /* A tile whose photo hasn't loaded has no intrinsic width, so without a floor the
+     timeline rail's jump lands hundreds of collapsed tiles in one row -- they end up with
+     no area, the browser never lazy-loads them, and they never gain a width. Reserving a
+     minimum breaks that deadlock. Loaded photos are wider than this at 50vh, so it has no
+     effect on the justified layout. */
+  min-width: 200px;
 
   @media (max-width: 768px) {
     width: 100%;
@@ -181,13 +240,13 @@ const FlexImage = styled.img`
 //     grid-gap: 5px;
 //     grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
 //     /* grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); */
-   
+
 //     /* grid-template-columns: repeat(4, 1fr); */
 // `;
 
 // const GridImage = styled.div`
 //     background-position: center center;
 //     background-repeat: no-repeat;
-//     background-size: cover; 
+//     background-size: cover;
 //     height: 200px;
 // `;

--- a/components/TimelineRail.tsx
+++ b/components/TimelineRail.tsx
@@ -1,0 +1,118 @@
+import styled from 'styled-components'
+import { MonthMarker } from '../lib/photos'
+
+interface IOwnProps {
+  markers: MonthMarker[]
+  activeMonth: number | null
+  onJump: (marker: MonthMarker) => void
+}
+
+// A scrubber down the right edge of an album. The bar next to each month is scaled to how
+// many shots that month has, so a year's shape is legible at a glance -- the Decembers are
+// always fat. Clicking a month reveals enough of the grid to reach it and scrolls there.
+export default function TimelineRail({ markers, activeMonth, onJump }: IOwnProps) {
+  if (markers.length === 0) return null
+
+  const busiest = Math.max(...markers.map((m) => m.count))
+
+  return (
+    <Rail aria-label="Jump to month">
+      {markers.map((marker) => (
+        <MonthButton
+          key={marker.month}
+          type="button"
+          $active={marker.month === activeMonth}
+          onClick={() => onJump(marker)}
+          title={`${marker.count} from ${marker.label}`}
+        >
+          <MonthLabel>{marker.label}</MonthLabel>
+          <Bar $fill={marker.count / busiest} $active={marker.month === activeMonth} />
+          <MonthCount>{marker.count}</MonthCount>
+        </MonthButton>
+      ))}
+    </Rail>
+  )
+}
+
+const Rail = styled.nav`
+  position: fixed;
+  right: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  z-index: 5;
+  padding: 8px 6px;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.railBackground};
+  backdrop-filter: blur(6px);
+
+  /* Slides down to a horizontal strip under the header rather than covering the photos. */
+  @media (max-width: 768px) {
+    position: sticky;
+    top: 0;
+    right: auto;
+    transform: none;
+    flex-direction: row;
+    gap: 0;
+    overflow-x: auto;
+    border-radius: 0;
+    margin: 0 0 6px 0;
+    padding: 6px 2px;
+  }
+`
+
+const MonthButton = styled.button<{ $active: boolean }>`
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 2px 4px;
+  font-family: inherit;
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  color: ${({ theme }) => theme.text};
+  opacity: ${({ $active }) => ($active ? 1 : 0.45)};
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 2px;
+  }
+`
+
+const MonthLabel = styled.span`
+  width: 26px;
+  text-align: right;
+  text-transform: uppercase;
+`
+
+const Bar = styled.span<{ $fill: number; $active: boolean }>`
+  display: block;
+  height: 3px;
+  border-radius: 2px;
+  /* Floor keeps a one-photo month from rendering as an invisible sliver. */
+  width: ${({ $fill }) => Math.max(6, Math.round($fill * 46))}px;
+  background-color: ${({ $active, theme }) => ($active ? theme.accent : theme.text)};
+
+  @media (max-width: 768px) {
+    width: 26px;
+  }
+`
+
+const MonthCount = styled.span`
+  width: 26px;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`

--- a/lib/photos.ts
+++ b/lib/photos.ts
@@ -1,0 +1,153 @@
+import { S3Client, paginateListObjectsV2 } from '@aws-sdk/client-s3'
+
+// Shared S3 access + filename parsing. Both the album page and the home page
+// preview strips read through here so there is one definition of "what is in a year".
+
+const SUPPORTED_FILES = ['jpg', 'gif', 'webp']
+const BUCKET = 'yearbook-assets'
+
+const s3 = new S3Client({
+  region: 'us-east-1',
+  credentials: {
+    accessKeyId: process.env.AWS_S3_ACCESS_KEY as string,
+    secretAccessKey: process.env.AWS_S3_SECRET as string,
+  },
+})
+
+// Paginates past the 1000-key cap that a bare ListObjectsV2 silently truncates at.
+// Only includes keys ending in SUPPORTED_FILES -- filters out directories and any
+// weird files like .DS_Store.
+async function listKeys(prefix: string): Promise<string[]> {
+  const keys: string[] = []
+
+  for await (const page of paginateListObjectsV2({ client: s3 }, { Bucket: BUCKET, Prefix: prefix })) {
+    for (const { Key } of page.Contents ?? []) {
+      const lower = Key?.toLowerCase()
+      if (Key && lower && SUPPORTED_FILES.some((ext) => lower.endsWith(ext))) {
+        keys.push(Key)
+      }
+    }
+  }
+
+  return keys
+}
+
+// The home page lists every year at once, so without this each page load would fan out
+// 15 paginated bucket listings. Keys only change when new photos are uploaded, so a short
+// process-local TTL is plenty -- and it resets on every deploy anyway.
+const CACHE_TTL_MS = 5 * 60 * 1000
+const cache = new Map<string, { at: number; keys: string[] }>()
+
+export const fileName = (key: string) => key.split('/').pop() ?? key
+
+// Sorts by filename only -- keys are timestamp-prefixed, so this is chronological.
+// Photos live in {year}/200px and videos in {year}/video/webp, and interleaving them
+// by name puts a clip in the middle of the day it was shot.
+function byFileName(a: string, b: string) {
+  const aName = fileName(a)
+  const bName = fileName(b)
+
+  if (aName === bName) return 0
+  return aName < bName ? -1 : 1
+}
+
+export async function listAlbum(year: string): Promise<string[]> {
+  const hit = cache.get(year)
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) {
+    return hit.keys
+  }
+
+  const [photos, videos] = await Promise.all([
+    listKeys(`${year}/200px`),
+    listKeys(`${year}/video/webp`),
+  ])
+
+  const keys = videos.concat(photos).sort(byFileName)
+  cache.set(year, { at: Date.now(), keys })
+
+  return keys
+}
+
+// Every key across all 15 years is named YYYYMMDD-... -- both the stills
+// (20250102-202907-9243.webp) and the clips (20250301-IMG_1286-...webp).
+const DATE_RE = /^(\d{4})(\d{2})(\d{2})/
+
+export function keyDate(key: string): { year: number; month: number; day: number } | null {
+  const match = DATE_RE.exec(fileName(key))
+  if (!match) return null
+
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (month < 1 || month > 12 || day < 1 || day > 31) return null
+
+  return { year: Number(match[1]), month, day }
+}
+
+export const MONTH_NAMES = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+]
+
+export const MONTH_ABBR = MONTH_NAMES.map((m) => m.slice(0, 3))
+
+// "January 2, 2025" -- shown as the lightbox caption. Built from the filename rather than
+// EXIF so it costs nothing; anything unparseable just gets no caption.
+export function formatKeyDate(key: string): string | null {
+  const parsed = keyDate(key)
+  if (!parsed) return null
+
+  return `${MONTH_NAMES[parsed.month - 1]} ${parsed.day}, ${parsed.year}`
+}
+
+export interface MonthMarker {
+  month: number
+  label: string
+  count: number
+  // Index into the album's key list of the first item in this month -- what the rail
+  // scrolls to, and how far the grid has to reveal before that item exists in the DOM.
+  index: number
+}
+
+// Walks the (already chronological) key list and records where each month starts.
+export function monthMarkers(keys: string[]): MonthMarker[] {
+  const markers: MonthMarker[] = []
+
+  keys.forEach((key, index) => {
+    const parsed = keyDate(key)
+    if (!parsed) return
+
+    const last = markers[markers.length - 1]
+    if (last && last.month === parsed.month) {
+      last.count += 1
+      return
+    }
+
+    markers.push({
+      month: parsed.month,
+      label: MONTH_ABBR[parsed.month - 1],
+      count: 1,
+      index,
+    })
+  })
+
+  return markers
+}
+
+// Picks `count` items spread evenly across the year for the home page preview strip,
+// so a year reads as January-to-December rather than as one afternoon in March.
+export function spreadSample(keys: string[], count: number): string[] {
+  if (keys.length <= count) return keys
+
+  const step = keys.length / count
+  return Array.from({ length: count }, (_, i) => keys[Math.floor(i * step)])
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 module.exports = {
   reactStrictMode: true,
+  // Two `next dev` instances in one checkout fight over the .next/dev lock. Setting
+  // NEXT_DIST_DIR gives a second instance its own build dir; unset, nothing changes.
+  distDir: process.env.NEXT_DIST_DIR || '.next',
   compiler: {
     // Replaces the babel-plugin-styled-components config that used to live in .babelrc.
     // Keeping it here lets Next use SWC/Turbopack instead of falling back to Babel.

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,0 +1,34 @@
+import Document, { DocumentContext, DocumentInitialProps } from 'next/document'
+import { Children } from 'react'
+import { ServerStyleSheet } from 'styled-components'
+
+// Without this, styled-components only injects its CSS once the bundle has hydrated, so the
+// server-rendered HTML arrives with no styling at all. On a fast connection that flashes by;
+// on a slow one the home page spends several seconds as a wall of full-size <img> tags,
+// because a preview thumbnail is only 34px wide by virtue of CSS that hasn't arrived yet.
+//
+// Collecting the stylesheet during SSR ships those rules in the document itself, so the
+// first paint is already laid out. `compiler.styledComponents` in next.config.js is what
+// keeps the generated class names identical on both sides.
+export default class MyDocument extends Document {
+  static async getInitialProps(ctx: DocumentContext): Promise<DocumentInitialProps> {
+    const sheet = new ServerStyleSheet()
+    const originalRenderPage = ctx.renderPage
+
+    try {
+      ctx.renderPage = () =>
+        originalRenderPage({
+          enhanceApp: (App) => (props) => sheet.collectStyles(<App {...props} />),
+        })
+
+      const initialProps = await Document.getInitialProps(ctx)
+
+      return {
+        ...initialProps,
+        styles: [...Children.toArray(initialProps.styles), sheet.getStyleElement()],
+      }
+    } finally {
+      sheet.seal()
+    }
+  }
+}

--- a/pages/album/[aid].tsx
+++ b/pages/album/[aid].tsx
@@ -1,109 +1,212 @@
 import '../../styles/Home.module.css'
 
-import ExifReader from 'exifreader';
+import { GetServerSidePropsContext } from 'next';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
-import { S3Client, paginateListObjectsV2 } from '@aws-sdk/client-s3';
-import AlbumContent from '../../components/AlbumContent';
-import { useState } from 'react';
+import AlbumContent, { photoDomId } from '../../components/AlbumContent';
+import TimelineRail from '../../components/TimelineRail';
 
-import { ThemeProvider } from "styled-components";
+import styled, { ThemeProvider } from "styled-components";
 import { lightTheme, darkTheme, GlobalStyles, THEMES } from '../../ThemeConfig';
 import { assetUrl } from '../../AssetConfig';
+import { fileName, formatKeyDate, keyDate, listAlbum, monthMarkers, MonthMarker } from '../../lib/photos';
 import Link from 'next/link';
 import { TopBar, MainContentWrapper, MainContent, Header, LightSwitch } from '../../components/SharedComponents';
+
 import Lightbox from "yet-another-react-lightbox";
+import Captions from "yet-another-react-lightbox/plugins/captions";
+import Counter from "yet-another-react-lightbox/plugins/counter";
+import Fullscreen from "yet-another-react-lightbox/plugins/fullscreen";
+import Slideshow from "yet-another-react-lightbox/plugins/slideshow";
+import Thumbnails from "yet-another-react-lightbox/plugins/thumbnails";
+import Zoom from "yet-another-react-lightbox/plugins/zoom";
 import "yet-another-react-lightbox/styles.css";
+import "yet-another-react-lightbox/plugins/captions.css";
+import "yet-another-react-lightbox/plugins/counter.css";
+import "yet-another-react-lightbox/plugins/thumbnails.css";
 
-const SUPPORTED_FILES = ['jpg', 'gif', 'webp'];
-const BUCKET = 'yearbook-assets';
-
-const s3 = new S3Client({
-  region: 'us-east-1',
-  credentials: {
-    accessKeyId: process.env.AWS_S3_ACCESS_KEY as string,
-    secretAccessKey: process.env.AWS_S3_SECRET as string,
-  },
-});
-
-// Paginates past the 1000-key cap that a bare ListObjectsV2 silently truncates at.
-// Only includes keys ending in SUPPORTED_FILES -- filters out directories and any
-// weird files like .DS_Store.
-async function listKeys(prefix: string): Promise<string[]> {
-  const keys: string[] = [];
-
-  for await (const page of paginateListObjectsV2({ client: s3 }, { Bucket: BUCKET, Prefix: prefix })) {
-    for (const { Key } of page.Contents ?? []) {
-      const lower = Key?.toLowerCase();
-      if (Key && lower && SUPPORTED_FILES.some((ext) => lower.endsWith(ext))) {
-        keys.push(Key);
-      }
-    }
-  }
-
-  return keys;
+interface IAlbumProps {
+  data: string[],
+  year: string,
 }
 
-export async function getServerSideProps(context: any) {
-  const aid = context.query.aid
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const aid = String(context.query.aid)
 
-  const [photoResult, videoResult] = await Promise.all([
-    listKeys(`${aid}/200px`),
-    listKeys(`${aid}/video/webp`),
-  ]);
-
-  // Concat the photos and videos and custom sort
-  // TODO: faster to do a smarter merge
-  const res = videoResult.concat(photoResult).sort((a, b) =>{
-    const aParts = a?.split('/');
-    const bParts = b?.split('/');
-
-    let aTime = '';
-    let bTime = '';
-
-    if (aParts && bParts) {
-      aTime = aParts[aParts.length - 1];
-      bTime = bParts[bParts.length - 1];     
-    }
-
-    if (!aTime || aTime < bTime) {
-      return -1;
-    } else if (!bTime || aTime > bTime) {
-      return 1;
-    }
-    return 0;
-  });
-
-  return { props: { data: res, year: aid } };
+  return { props: { data: await listAlbum(aid), year: aid } };
 }
 
-const Album = (data: any) => {
-  console.log(data.year)
+// Stable, human-readable id for a single shot -- '2025/200px/20250102-202907-9243.webp'
+// becomes '20250102-202907-9243'. Used as the #photo= fragment so a link to one photo
+// survives re-uploads and size changes.
+const photoSlug = (key: string) => fileName(key).replace(/\.[^.]+$/, '');
 
-  const images = data.data;
-  const year = data.year;
+// Leaves a jumped-to photo clear of the header rather than tucked under it.
+const HEADER_OFFSET = 80;
 
+// How long a jump keeps correcting for images loading in above it: it stops once nothing
+// new has arrived for QUIET_MS, and never holds on past MAX_PIN_MS.
+const QUIET_MS = 2500;
+const MAX_PIN_MS = 30000;
+
+const readPhotoHash = () => {
+  const match = /#photo=([^&]+)/.exec(window.location.hash);
+  return match ? decodeURIComponent(match[1]) : null;
+};
+
+const Album = ({ data: images, year }: IAlbumProps) => {
   const [theme, setTheme] = useState(THEMES.DARK.name);
   const [lightboxOpen, setLightboxOpen] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(0);
+  const [autoplay, setAutoplay] = useState(false);
+  const [activeMonth, setActiveMonth] = useState<number | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const albumRef = useRef<AlbumContent>(null);
+  // Bumped on every jump so an in-flight settle loop knows it has been superseded.
+  const jumpToken = useRef(0);
+
+  const markers = useMemo(() => monthMarkers(images ?? []), [images]);
+  const slugs = useMemo(() => (images ?? []).map(photoSlug), [images]);
+
+  const slides = useMemo(
+    () =>
+      (images ?? []).map((path: string) => ({
+        src: assetUrl(path.replace('200px', '3000px')),
+        thumbnail: assetUrl(path),
+        title: formatKeyDate(path) ?? undefined,
+      })),
+    [images]
+  );
 
   const toggleTheme = () => {
     theme == THEMES.LIGHT.name ? setTheme(THEMES.DARK.name) : setTheme(THEMES.LIGHT.name);
   }
 
-  const openLightbox = (index: number) => {
+  // Reveals enough of the grid to reach `index` and parks that photo under the header.
+  //
+  // Jumping to December means rendering hundreds of tiles at once, and a tile whose image
+  // hasn't loaded has no intrinsic width -- so the justified rows re-wrap and everything
+  // below shifts by thousands of pixels as the images arrive. One scroll lands nowhere near
+  // the target, and a fixed-duration retry loop gives up while photos are still arriving.
+  // So we re-pin the target every time an image finishes loading, until the album goes quiet
+  // -- and bail out the moment the reader takes over.
+  const scrollToPhoto = useCallback((index: number) => {
+    const token = ++jumpToken.current;
+
+    albumRef.current?.revealThrough(index, () => {
+      const grid = document.getElementById('page-main-grid');
+      if (!grid) return;
+
+      const started = Date.now();
+      let cancelled = false;
+      let quietTimer: ReturnType<typeof setTimeout>;
+      let pinQueued = false;
+
+      const cancel = () => { cancelled = true; stop(); };
+
+      const stop = () => {
+        clearTimeout(quietTimer);
+        window.removeEventListener('wheel', cancel);
+        window.removeEventListener('touchstart', cancel);
+        window.removeEventListener('keydown', cancel);
+        // `load` doesn't bubble, so this listener has to capture.
+        grid.removeEventListener('load', onImageLoad, true);
+      };
+
+      const pin = () => {
+        if (cancelled || token !== jumpToken.current) return stop();
+
+        const target = document.getElementById(photoDomId(index));
+        if (!target) return stop();
+
+        const drift = target.getBoundingClientRect().top - HEADER_OFFSET;
+        if (Math.abs(drift) >= 2) {
+          window.scrollBy({ top: drift, behavior: 'auto' });
+        }
+      };
+
+      // Coalesce the burst of loads that fire together into one correction per frame.
+      const queuePin = () => {
+        if (pinQueued) return;
+        pinQueued = true;
+        window.requestAnimationFrame(() => {
+          pinQueued = false;
+          pin();
+        });
+      };
+
+      const onImageLoad = () => {
+        queuePin();
+        // Each arriving photo extends the window; when they stop, so do we. The gap is
+        // generous because these are 2000px files off the CDN -- a second between two
+        // arrivals is normal, and giving up early leaves the target halfway up the page.
+        clearTimeout(quietTimer);
+        if (Date.now() - started < MAX_PIN_MS) {
+          quietTimer = setTimeout(stop, QUIET_MS);
+        }
+      };
+
+      window.addEventListener('wheel', cancel, { passive: true });
+      window.addEventListener('touchstart', cancel, { passive: true });
+      window.addEventListener('keydown', cancel);
+      grid.addEventListener('load', onImageLoad, true);
+
+      pin();
+      quietTimer = setTimeout(stop, QUIET_MS);
+    });
+  }, []);
+
+  const openLightbox = useCallback((index: number) => {
+    setAutoplay(false);
     setLightboxIndex(index);
     setLightboxOpen(true);
-  }
+  }, []);
 
-  // if (error) return <div>failed to load</div>
+  const jumpToMonth = useCallback((marker: MonthMarker) => {
+    setActiveMonth(marker.month);
+    scrollToPhoto(marker.index);
+  }, [scrollToPhoto]);
+
+  const onVisibleIndexChange = useCallback((index: number) => {
+    const parsed = keyDate(images?.[index] ?? '');
+    if (parsed) setActiveMonth(parsed.month);
+  }, [images]);
+
+  const playTheYear = useCallback(() => {
+    setAutoplay(true);
+    setLightboxIndex(0);
+    setLightboxOpen(true);
+  }, []);
+
+  const copyPhotoLink = useCallback(() => {
+    const slug = slugs[lightboxIndex];
+    if (!slug) return;
+
+    const url = `${window.location.origin}${window.location.pathname}#photo=${encodeURIComponent(slug)}`;
+    navigator.clipboard?.writeText(url).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    });
+  }, [slugs, lightboxIndex]);
+
+  // Opening a shared link: find the photo named in the fragment, page the grid out to it,
+  // and open it straight into the lightbox.
+  useEffect(() => {
+    const slug = readPhotoHash();
+    if (!slug) return;
+
+    const index = slugs.indexOf(slug);
+    if (index < 0) return;
+
+    scrollToPhoto(index);
+    setLightboxIndex(index);
+    setLightboxOpen(true);
+    // Only on first paint -- later hash writes come from the lightbox itself.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   if (!images) return <div>loading...</div>
-
-  // EXIF stuff .. make this async
-  // const tags = ExifReader.load(data[0]).then(r => {
-  //   const lala = 1;
-  // })
-  // const imageDate = tags['DateTimeOriginal'].description;
-  // const unprocessedTagValue = tags['DateTimeOriginal'].value;
 
   const activeTheme = theme == THEMES.LIGHT.name ? lightTheme : darkTheme
 
@@ -115,21 +218,94 @@ const Album = (data: any) => {
         <MainContent>
           <Header>
             <h1 style={{ margin: '6px'}}><Link href='/'>←</Link> { year }</h1>
-            <LightSwitch onClick={toggleTheme}>{activeTheme.icon}</LightSwitch>
+            <HeaderActions>
+              <PlayButton type="button" onClick={playTheYear} title={`Play all ${images.length} in order`}>
+                ▶ play the year
+              </PlayButton>
+              <LightSwitch onClick={toggleTheme}>{activeTheme.icon}</LightSwitch>
+            </HeaderActions>
           </Header>
-          <AlbumContent items={images} year={year} onImageClick={openLightbox}/>
+          <TimelineRail markers={markers} activeMonth={activeMonth} onJump={jumpToMonth} />
+          <AlbumContent
+            ref={albumRef}
+            items={images}
+            year={year}
+            onImageClick={openLightbox}
+            onVisibleIndexChange={onVisibleIndexChange}
+          />
           <Lightbox
             open={lightboxOpen}
-            close={() => setLightboxOpen(false)}
+            close={() => {
+              setLightboxOpen(false);
+              setAutoplay(false);
+              // Drop the fragment so a refresh doesn't reopen the photo, and leave the
+              // grid parked on whatever you were just looking at.
+              history.replaceState(null, '', window.location.pathname);
+              scrollToPhoto(lightboxIndex);
+            }}
             index={lightboxIndex}
-            slides={images.map((path: string) => ({
-              src: assetUrl(path.replace('200px', '3000px'))
-            }))}
+            slides={slides}
+            plugins={[Captions, Counter, Fullscreen, Slideshow, Thumbnails, Zoom]}
+            on={{
+              view: ({ index }) => {
+                setLightboxIndex(index);
+                const slug = slugs[index];
+                if (slug) history.replaceState(null, '', `#photo=${encodeURIComponent(slug)}`);
+              },
+            }}
+            slideshow={{ autoplay, delay: 3000 }}
+            // showToggle is what actually renders the 'thumbnails' toolbar button below --
+            // without it the plugin ignores the entry and the toolbar prints the bare word.
+            thumbnails={{ width: 100, height: 70, borderRadius: 4, vignette: false, showToggle: true }}
+            counter={{ container: { style: { top: 'unset', bottom: 0 } } }}
+            carousel={{ finite: true }}
+            toolbar={{
+              buttons: [
+                <button
+                  key="copy-link"
+                  type="button"
+                  className="yarl__button"
+                  onClick={copyPhotoLink}
+                  title="Copy a link to this photo"
+                >
+                  {copied ? '✓ copied' : '🔗 link'}
+                </button>,
+                'slideshow',
+                'thumbnails',
+                'fullscreen',
+                'zoom',
+                'close',
+              ],
+            }}
           />
         </MainContent>
       </MainContentWrapper>
     </ThemeProvider>
   );
 }
+
+const HeaderActions = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const PlayButton = styled.button`
+  background: none;
+  border: 1px solid ${({ theme }) => theme.text};
+  border-radius: 999px;
+  color: ${({ theme }) => theme.text};
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 12px;
+  letter-spacing: 0.06em;
+  opacity: 0.65;
+  padding: 6px 12px;
+  transition: opacity 0.2s ease;
+
+  &:hover {
+    opacity: 1;
+  }
+`;
 
 export default Album

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -179,19 +179,29 @@ const LAYOUT_ICONS = {
   [LAYOUTS.GRID]: '🏁',
 };
 
+// Intrinsic sizes for the <img> tags. CSS sizes the tiles for real -- these are so the
+// browser knows the shape before the photo lands, and so an unstyled render degrades to
+// small images rather than full-bleed ones.
+const TILE_SIZES = {
+  [LAYOUTS.STRIP]: { width: 100, height: 72 },
+  [LAYOUTS.GRID]: { width: 34, height: 24 },
+};
+
 interface ITileProps {
   href: string,
   src: string,
   label: string,
+  layout: PreviewLayout,
   // Staggers the shimmer across the row so it reads as a sweep rather than one flat pulse.
   index: number,
 }
 
 // A single preview thumbnail. Shimmers in place until its photo paints over it -- a year's
 // worth of grid tiles is ~70 lazy requests, so they arrive in a trickle rather than at once.
-function PreviewTile({ href, src, label, index }: ITileProps) {
+function PreviewTile({ href, src, label, layout, index }: ITileProps) {
   const [loaded, setLoaded] = useState(false);
   const imgRef = useRef<HTMLImageElement>(null);
+  const size = TILE_SIZES[layout];
 
   // A cached photo -- or one the server-rendered markup finished fetching before React
   // hydrated -- has already fired its load event by the time onLoad is attached, and would
@@ -210,6 +220,8 @@ function PreviewTile({ href, src, label, index }: ITileProps) {
       <Thumb
         ref={imgRef}
         src={src}
+        width={size.width}
+        height={size.height}
         loading="lazy"
         alt=""
         onLoad={() => setLoaded(true)}
@@ -272,6 +284,7 @@ function Home({ previews }: IHomeProps) {
                           <PreviewTile
                             key={key}
                             index={index}
+                            layout={layout}
                             src={assetUrl(key)}
                             href={`/album/${a.year}/#photo=${encodeURIComponent(photoSlug(key))}`}
                             label={`Open ${a.year} at this photo`}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -412,6 +412,12 @@ const rightAlignedScroller = css`
 
     @media (max-width: 768px) {
       margin-left: 12px;
+      /* The row becomes a column here, and its align-items: flex-start sizes children to
+         their content on the cross axis -- so the previews claimed their full ~720px and ran
+         off the side of the phone, with overflow-x never given a constraint to act on.
+         Stretching to the column's width supplies one. */
+      align-self: stretch;
+      max-width: 100%;
     }
 `;
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,7 +1,7 @@
 import '../styles/Home.module.css'
 
-import { useState } from 'react';
-import styled from 'styled-components';
+import { useEffect, useRef, useState } from 'react';
+import styled, { css, keyframes } from 'styled-components';
 
 import { ThemeProvider } from 'styled-components';
 import { lightTheme, darkTheme, GlobalStyles, THEMES } from '../ThemeConfig';
@@ -126,11 +126,16 @@ const ALBUMS = [
   }
 ];
 
-const PREVIEW_COUNT = 8;
+// Two ways to preview a year in the same footprint: one row of readable thumbnails, or three
+// rows of small ones holding roughly nine times as many shots. Switched from the header.
+const STRIP_COUNT = 8;
+const GRID_COUNT = 72;
 
 interface IYearPreview {
-  // Thumbnail keys, spread across the year, each linking into the album at that photo.
-  keys: string[],
+  // Keys spread across the year, each linking into the album at that photo. Two samples
+  // because the grid holds an order of magnitude more shots in the same space.
+  strip: string[],
+  grid: string[],
 }
 
 interface IHomeProps {
@@ -146,11 +151,14 @@ export async function getServerSideProps() {
 
       try {
         const keys = await listAlbum(year);
-        return [year, { keys: spreadSample(keys, PREVIEW_COUNT) }] as const;
+        return [
+          year,
+          { strip: spreadSample(keys, STRIP_COUNT), grid: spreadSample(keys, GRID_COUNT) },
+        ] as const;
       } catch {
         // A year that fails to list just renders without its strip -- the descriptions,
         // which are the point of this page, still come through.
-        return [year, { keys: [] }] as const;
+        return [year, { strip: [], grid: [] }] as const;
       }
     })
   );
@@ -158,16 +166,76 @@ export async function getServerSideProps() {
   return { props: { previews: Object.fromEntries(entries) } };
 }
 
+const LAYOUTS = {
+  STRIP: 'strip',
+  GRID: 'grid',
+} as const;
+
+type PreviewLayout = (typeof LAYOUTS)[keyof typeof LAYOUTS];
+
+// Matches the light switch next to it, which shows the icon of the mode you are in.
+const LAYOUT_ICONS = {
+  [LAYOUTS.STRIP]: '🎞️',
+  [LAYOUTS.GRID]: '🏁',
+};
+
+interface ITileProps {
+  href: string,
+  src: string,
+  label: string,
+  // Staggers the shimmer across the row so it reads as a sweep rather than one flat pulse.
+  index: number,
+}
+
+// A single preview thumbnail. Shimmers in place until its photo paints over it -- a year's
+// worth of grid tiles is ~70 lazy requests, so they arrive in a trickle rather than at once.
+function PreviewTile({ href, src, label, index }: ITileProps) {
+  const [loaded, setLoaded] = useState(false);
+  const imgRef = useRef<HTMLImageElement>(null);
+
+  // A cached photo -- or one the server-rendered markup finished fetching before React
+  // hydrated -- has already fired its load event by the time onLoad is attached, and would
+  // otherwise shimmer forever underneath a perfectly good picture.
+  useEffect(() => {
+    if (imgRef.current?.complete) setLoaded(true);
+  }, []);
+
+  return (
+    <Tile
+      href={href}
+      aria-label={label}
+      $loaded={loaded}
+      style={{ animationDelay: `${(index % 12) * -0.18}s` }}
+    >
+      <Thumb
+        ref={imgRef}
+        src={src}
+        loading="lazy"
+        alt=""
+        onLoad={() => setLoaded(true)}
+        // A photo that 404s should stop shimmering too -- it is done, just empty.
+        onError={() => setLoaded(true)}
+      />
+    </Tile>
+  );
+}
+
 const photoSlug = (key: string) => fileName(key).replace(/\.[^.]+$/, '');
 
 function Home({ previews }: IHomeProps) {
   const [theme, setTheme] = useState(THEMES.DARK.name);
+  const [layout, setLayout] = useState<PreviewLayout>(LAYOUTS.GRID);
 
   const toggleTheme = () => {
     theme == THEMES.LIGHT.name ? setTheme(THEMES.DARK.name) : setTheme(THEMES.LIGHT.name);
   }
 
+  const toggleLayout = () => {
+    setLayout(layout === LAYOUTS.STRIP ? LAYOUTS.GRID : LAYOUTS.STRIP);
+  }
+
   const activeTheme = theme == THEMES.LIGHT.name ? lightTheme : darkTheme
+  const PreviewBox = layout === LAYOUTS.GRID ? PreviewGrid : PreviewStrip
 
   return (
     <ThemeProvider theme={activeTheme}>
@@ -177,7 +245,16 @@ function Home({ previews }: IHomeProps) {
         <MainContent>
           <Header>
             <h1 style={{ margin: '6px'}}>yearbooks</h1>
-            <LightSwitch onClick={toggleTheme}>{activeTheme.icon}</LightSwitch>
+            <HeaderActions>
+              <LayoutSwitch
+                onClick={toggleLayout}
+                type="button"
+                title={layout === LAYOUTS.GRID ? 'Switch to filmstrip previews' : 'Switch to grid previews'}
+              >
+                {LAYOUT_ICONS[layout]}
+              </LayoutSwitch>
+              <LightSwitch onClick={toggleTheme}>{activeTheme.icon}</LightSwitch>
+            </HeaderActions>
           </Header>
           <div style={{ margin: '6px'}}>
             {ALBUMS.map((a) => {
@@ -189,18 +266,18 @@ function Home({ previews }: IHomeProps) {
                     <YearHeader>
                       <Link href={`/album/${a.year}/`}>{a.year}</Link>
                     </YearHeader>
-                    {preview && preview.keys.length > 0 && (
-                      <PreviewStrip>
-                        {preview.keys.map((key) => (
-                          <Link
+                    {preview && preview[layout].length > 0 && (
+                      <PreviewBox>
+                        {preview[layout].map((key, index) => (
+                          <PreviewTile
                             key={key}
+                            index={index}
+                            src={assetUrl(key)}
                             href={`/album/${a.year}/#photo=${encodeURIComponent(photoSlug(key))}`}
-                            aria-label={`Open ${a.year} at this photo`}
-                          >
-                            <PreviewThumb src={assetUrl(key)} loading="lazy" alt="" />
-                          </Link>
+                            label={`Open ${a.year} at this photo`}
+                          />
                         ))}
-                      </PreviewStrip>
+                      </PreviewBox>
                     )}
                   </YearRow>
                   <div style={{ paddingLeft: '12px'}}>
@@ -237,6 +314,57 @@ const YearRow = styled.div`
     }
 `;
 
+const HeaderActions = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+/* Sits beside the light switch and reads the same way: the icon shows the mode you are in. */
+const LayoutSwitch = styled.button`
+    background: none;
+    border: none;
+    padding: 0;
+    color: inherit;
+    cursor: pointer;
+    font-size: 30px;
+    line-height: 1;
+    margin: 6px;
+`;
+
+/* Silver and gold, kept faint -- it should read as a placeholder catching the light, not as
+   content. The gradient is three times the tile width and slides across it. */
+const shimmer = keyframes`
+    from { background-position: 200% 0; }
+    to { background-position: -100% 0; }
+`;
+
+const Tile = styled(Link)<{ $loaded: boolean }>`
+    display: block;
+    min-width: 0;
+    border-radius: 2px;
+    overflow: hidden;
+
+    ${({ $loaded }) =>
+      !$loaded &&
+      css`
+        background-image: linear-gradient(
+          100deg,
+          rgba(192, 192, 192, 0.06) 20%,
+          rgba(212, 175, 55, 0.16) 38%,
+          rgba(229, 228, 226, 0.22) 50%,
+          rgba(212, 175, 55, 0.16) 62%,
+          rgba(192, 192, 192, 0.06) 80%
+        );
+        background-size: 300% 100%;
+        animation: ${shimmer} 2.2s linear infinite;
+      `}
+
+    /* Respect a reduced-motion preference -- the placeholder still reads without the sweep. */
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+`;
+
 const YearHeader = styled.h2`
     text-decoration: none;
     /* text-shadow: 3px -3px #3058c5, 5px -5px #d5b6c5; */
@@ -249,38 +377,80 @@ const YearHeader = styled.h2`
     flex-shrink: 0;
 `;
 
-const PreviewStrip = styled.div`
-    display: flex;
-    gap: 4px;
-    /* min-width: 0 is what lets overflow-x actually kick in inside a flex row -- without it
-       the strip claims its full content width and pushes the year off the page. */
-    flex: 1;
+/* Shared by both preview treatments: sized to its contents and pushed to the right edge, so
+   the previews line up against the right margin while the years stay left. min-width: 0 with
+   a shrinkable basis is what lets overflow-x kick in when the thumbnails outgrow the space
+   left beside the year -- otherwise the preview claims its full content width and shoves the
+   year off the page. (justify-content: flex-end would right-align them too, but it puts the
+   overflow off the left edge where it can't be scrolled back to.) */
+const rightAlignedScroller = css`
+    flex: 0 1 auto;
     min-width: 0;
+    margin-left: auto;
     overflow-x: auto;
-    padding-bottom: 4px;
+
+    /* Still scrollable by wheel/trackpad/touch -- just without the bar, which was costing a
+       few pixels of height and reading as chrome on what should look like a strip of film. */
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
 
     @media (max-width: 768px) {
       margin-left: 12px;
     }
 `;
 
-const PreviewThumb = styled.img`
-    height: 86px;
-    width: 120px;
-    object-fit: cover;
-    border-radius: 3px;
-    display: block;
-    opacity: 0.82;
-    transition: opacity 0.2s ease, transform 0.2s ease;
+/* The containers own the tile geometry -- a tile has to hold its size before its photo
+   arrives, or there'd be nothing for the placeholder shimmer to fill. */
+const PreviewStrip = styled.div`
+    display: flex;
+    gap: 4px;
+    ${rightAlignedScroller}
 
-    &:hover {
-      opacity: 1;
-      transform: translateY(-2px);
+    & > a {
+      flex: 0 0 auto;
+      width: 100px;
+      height: 72px;
     }
 
     @media (max-width: 768px) {
-      height: 70px;
-      width: 94px;
+      & > a {
+        width: 84px;
+        height: 60px;
+      }
+    }
+`;
+
+/* The micro grid: same footprint as the filmstrip, but three rows of much smaller shots, so
+   a year reads as a mosaic of ~70 moments instead of 8 legible ones. Columns flow left to
+   right, so time still runs across the page; each column is three consecutive shots. */
+const PreviewGrid = styled.div`
+    display: grid;
+    grid-template-rows: repeat(3, 24px);
+    grid-auto-flow: column;
+    grid-auto-columns: 34px;
+    gap: 2px;
+    ${rightAlignedScroller}
+
+    @media (max-width: 768px) {
+      grid-template-rows: repeat(3, 20px);
+      grid-auto-columns: 28px;
+    }
+`;
+
+/* Fills whichever tile it lands in, so one thumbnail serves both layouts. */
+const Thumb = styled.img`
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+    opacity: 0.82;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
     }
 `;
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -185,22 +185,24 @@ function Home({ previews }: IHomeProps) {
 
               return (
                 <div key={a.year} style={{letterSpacing: '0.03em', lineHeight: '1.5em'}}>
-                  <YearHeader>
-                    <Link href={`/album/${a.year}/`}>{a.year}</Link>
-                  </YearHeader>
-                  {preview && preview.keys.length > 0 && (
-                    <PreviewStrip>
-                      {preview.keys.map((key) => (
-                        <Link
-                          key={key}
-                          href={`/album/${a.year}/#photo=${encodeURIComponent(photoSlug(key))}`}
-                          aria-label={`Open ${a.year} at this photo`}
-                        >
-                          <PreviewThumb src={assetUrl(key)} loading="lazy" alt="" />
-                        </Link>
-                      ))}
-                    </PreviewStrip>
-                  )}
+                  <YearRow>
+                    <YearHeader>
+                      <Link href={`/album/${a.year}/`}>{a.year}</Link>
+                    </YearHeader>
+                    {preview && preview.keys.length > 0 && (
+                      <PreviewStrip>
+                        {preview.keys.map((key) => (
+                          <Link
+                            key={key}
+                            href={`/album/${a.year}/#photo=${encodeURIComponent(photoSlug(key))}`}
+                            aria-label={`Open ${a.year} at this photo`}
+                          >
+                            <PreviewThumb src={assetUrl(key)} loading="lazy" alt="" />
+                          </Link>
+                        ))}
+                      </PreviewStrip>
+                    )}
+                  </YearRow>
                   <div style={{ paddingLeft: '12px'}}>
                     {a.description.map((para, index) =>
                       <div key={index}>
@@ -219,6 +221,22 @@ function Home({ previews }: IHomeProps) {
   );
 }
 
+/* Puts the year and its contact sheet on one line, so the strip reads as a caption to the
+   year rather than a band across the page. Stacks back to two rows on a phone, where there
+   isn't room for both. */
+const YearRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 18px;
+    margin: 24px 0 10px 0;
+
+    @media (max-width: 768px) {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 6px;
+    }
+`;
+
 const YearHeader = styled.h2`
     text-decoration: none;
     /* text-shadow: 3px -3px #3058c5, 5px -5px #d5b6c5; */
@@ -226,16 +244,24 @@ const YearHeader = styled.h2`
     font-weight: 900;
     letter-spacing: 4px;
     padding-left: 2px;
-    margin-bottom: 8px;
+    margin: 0;
+    /* Keeps the year at full width while the strip absorbs the leftover space. */
+    flex-shrink: 0;
 `;
 
 const PreviewStrip = styled.div`
     display: flex;
     gap: 4px;
-    margin: 0 0 14px 12px;
-    /* Eight thumbnails is more than fits on a phone, so let the strip scroll sideways. */
+    /* min-width: 0 is what lets overflow-x actually kick in inside a flex row -- without it
+       the strip claims its full content width and pushes the year off the page. */
+    flex: 1;
+    min-width: 0;
     overflow-x: auto;
     padding-bottom: 4px;
+
+    @media (max-width: 768px) {
+      margin-left: 12px;
+    }
 `;
 
 const PreviewThumb = styled.img`

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,6 +7,8 @@ import { ThemeProvider } from 'styled-components';
 import { lightTheme, darkTheme, GlobalStyles, THEMES } from '../ThemeConfig';
 import Link from 'next/link';
 import { Header, LightSwitch, MainContent, MainContentWrapper, TopBar } from '../components/SharedComponents';
+import { assetUrl } from '../AssetConfig';
+import { fileName, listAlbum, spreadSample } from '../lib/photos';
 
 const ALBUMS = [
   {
@@ -124,7 +126,42 @@ const ALBUMS = [
   }
 ];
 
-function Home() {
+const PREVIEW_COUNT = 8;
+
+interface IYearPreview {
+  count: number,
+  // Thumbnail keys, spread across the year, each linking into the album at that photo.
+  keys: string[],
+}
+
+interface IHomeProps {
+  previews: Record<string, IYearPreview>,
+}
+
+// Pulls a handful of thumbnails per year so the index reads as a contact sheet instead of
+// a wall of text. listAlbum() caches per year, so this only hits S3 once every few minutes.
+export async function getServerSideProps() {
+  const entries = await Promise.all(
+    ALBUMS.map(async (album) => {
+      const year = String(album.year);
+
+      try {
+        const keys = await listAlbum(year);
+        return [year, { count: keys.length, keys: spreadSample(keys, PREVIEW_COUNT) }] as const;
+      } catch {
+        // A year that fails to list just renders without its strip -- the descriptions,
+        // which are the point of this page, still come through.
+        return [year, { count: 0, keys: [] }] as const;
+      }
+    })
+  );
+
+  return { props: { previews: Object.fromEntries(entries) } };
+}
+
+const photoSlug = (key: string) => fileName(key).replace(/\.[^.]+$/, '');
+
+function Home({ previews }: IHomeProps) {
   const [theme, setTheme] = useState(THEMES.DARK.name);
 
   const toggleTheme = () => {
@@ -145,11 +182,27 @@ function Home() {
           </Header>
           <div style={{ margin: '6px'}}>
             {ALBUMS.map((a) => {
+              const preview = previews?.[String(a.year)];
+
               return (
                 <div key={a.year} style={{letterSpacing: '0.03em', lineHeight: '1.5em'}}>
                   <YearHeader>
                     <Link href={`/album/${a.year}/`}>{a.year}</Link>
+                    {preview && preview.count > 0 && <YearCount>{preview.count} shots</YearCount>}
                   </YearHeader>
+                  {preview && preview.keys.length > 0 && (
+                    <PreviewStrip>
+                      {preview.keys.map((key) => (
+                        <Link
+                          key={key}
+                          href={`/album/${a.year}/#photo=${encodeURIComponent(photoSlug(key))}`}
+                          aria-label={`Open ${a.year} at this photo`}
+                        >
+                          <PreviewThumb src={assetUrl(key)} loading="lazy" alt="" />
+                        </Link>
+                      ))}
+                    </PreviewStrip>
+                  )}
                   <div style={{ paddingLeft: '12px'}}>
                     {a.description.map((para, index) =>
                       <div key={index}>
@@ -175,6 +228,48 @@ const YearHeader = styled.h2`
     font-weight: 900;
     letter-spacing: 4px;
     padding-left: 2px;
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    margin-bottom: 8px;
+`;
+
+const YearCount = styled.span`
+    font-size: 11px;
+    font-weight: 400;
+    letter-spacing: 0.08em;
+    opacity: 0.45;
+    text-shadow: none;
+    font-variant-numeric: tabular-nums;
+`;
+
+const PreviewStrip = styled.div`
+    display: flex;
+    gap: 4px;
+    margin: 0 0 14px 12px;
+    /* Eight thumbnails is more than fits on a phone, so let the strip scroll sideways. */
+    overflow-x: auto;
+    padding-bottom: 4px;
+`;
+
+const PreviewThumb = styled.img`
+    height: 86px;
+    width: 120px;
+    object-fit: cover;
+    border-radius: 3px;
+    display: block;
+    opacity: 0.82;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+      transform: translateY(-2px);
+    }
+
+    @media (max-width: 768px) {
+      height: 70px;
+      width: 94px;
+    }
 `;
 
 export default Home

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -129,7 +129,6 @@ const ALBUMS = [
 const PREVIEW_COUNT = 8;
 
 interface IYearPreview {
-  count: number,
   // Thumbnail keys, spread across the year, each linking into the album at that photo.
   keys: string[],
 }
@@ -147,11 +146,11 @@ export async function getServerSideProps() {
 
       try {
         const keys = await listAlbum(year);
-        return [year, { count: keys.length, keys: spreadSample(keys, PREVIEW_COUNT) }] as const;
+        return [year, { keys: spreadSample(keys, PREVIEW_COUNT) }] as const;
       } catch {
         // A year that fails to list just renders without its strip -- the descriptions,
         // which are the point of this page, still come through.
-        return [year, { count: 0, keys: [] }] as const;
+        return [year, { keys: [] }] as const;
       }
     })
   );
@@ -188,7 +187,6 @@ function Home({ previews }: IHomeProps) {
                 <div key={a.year} style={{letterSpacing: '0.03em', lineHeight: '1.5em'}}>
                   <YearHeader>
                     <Link href={`/album/${a.year}/`}>{a.year}</Link>
-                    {preview && preview.count > 0 && <YearCount>{preview.count} shots</YearCount>}
                   </YearHeader>
                   {preview && preview.keys.length > 0 && (
                     <PreviewStrip>
@@ -228,19 +226,7 @@ const YearHeader = styled.h2`
     font-weight: 900;
     letter-spacing: 4px;
     padding-left: 2px;
-    display: flex;
-    align-items: baseline;
-    gap: 12px;
     margin-bottom: 8px;
-`;
-
-const YearCount = styled.span`
-    font-size: 11px;
-    font-weight: 400;
-    letter-spacing: 0.08em;
-    opacity: 0.45;
-    text-shadow: none;
-    font-variant-numeric: tabular-nums;
 `;
 
 const PreviewStrip = styled.div`

--- a/styled.d.ts
+++ b/styled.d.ts
@@ -1,0 +1,9 @@
+import 'styled-components'
+import { ThemeType } from './ThemeConfig'
+
+// Teaches styled-components what `props.theme` holds, so components can read
+// theme.accent / theme.railBackground without casting.
+declare module 'styled-components' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  export interface DefaultTheme extends ThemeType {}
+}


### PR DESCRIPTION
Three ways to get around a year, plus the fixes that fell out of building them.

## Timeline rail

A scrubber down the right edge of an album, one row per month with a bar scaled to that month's count. Clicking a month reveals enough of the grid to reach it and scrolls there; the rail highlights whatever month you're scrolled through. Built off the `YYYYMMDD-` filename prefix, which is consistent across all fifteen years.

## Shareable photo links

The lightbox writes `#photo=<name>` as you navigate, a 🔗 button copies that URL, and opening one pages the grid out to that photo and opens it. The lightbox also gained date captions, a counter, a thumbnail strip (using the 200px assets, not the 3000px originals), zoom, fullscreen, and a slideshow driven by a **▶ play the year** button.

## Year previews on the home page

Each year gets a contact sheet beside its title, right-aligned against the margin. Two treatments, switched by an emoji button next to the light switch:

- **🏁 micro grid** (default) — 72 shots as three rows of 34×24 tiles
- **🎞️ filmstrip** — 8 readable thumbnails at 100×72

Same footprint either way. Tiles shimmer silver and gold until their photo lands, staggered across each row.

## Fixes found along the way

- **styled-components CSS was never server-rendered.** No `_document.tsx` meant the server HTML shipped with zero styling until the bundle hydrated — a flash on fast connections, several seconds of full-size `<img>` tags when throttled. Verified fixed by rendering the raw server HTML with no JS at all. This affected the album page too.
- **Revealed-but-unloaded tiles collapsed to zero width**, so hundreds packed into one row, ended up with no area, and the browser never lazy-loaded them — they could never gain a width. A `min-width` floor breaks the deadlock.
- **The album grid's scroll listener removed itself** after the first batch, leaving loading to a 500ms interval.
- **Previews ran off the side on narrow screens** — once the year row becomes a column, `align-items: flex-start` sizes children to content, so `overflow-x` had no constraint to act on.
- **Cached thumbnails shimmered forever**, since the image fires `load` before React attaches `onLoad`.

## Notes

- S3 listing moved to `lib/photos.ts`, shared by both pages with a short cache since the home page now lists every year at once. No extra S3 traffic for the second sample.
- `next.config.js` gained a `NEXT_DIST_DIR` escape hatch so a second `next dev`/`next start` can run in one checkout. Default unchanged.
- `npm run lint` is broken on `main` (ESLint 9 wants a flat config, repo has `.eslintrc.json`) — untouched here. `tsc --noEmit` is clean.
- Verified against a local production build. `next dev` in this checkout intermittently fails to hydrate; that reproduces on unmodified `main`, and the `_document.tsx` fix may well have improved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
